### PR TITLE
Try to add attest-build-provenance action

### DIFF
--- a/.github/workflows/goreleaser.yaml
+++ b/.github/workflows/goreleaser.yaml
@@ -7,7 +7,9 @@ on:
       - "*"
 
 permissions:
-  contents: write
+  id-token: write # for attestations
+  contents: write # for update release assets
+  attestations: write # for attestations
 
 jobs:
   goreleaser:
@@ -27,3 +29,8 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Generate artifact attestation
+        uses: actions/attest-build-provenance@v1
+        with:
+          subject-path: "dist/**/tfustomize*"
+          subject-name: "tk3fftk/tfustomize"


### PR DESCRIPTION
- refs:
  - [Artifact Attestations is generally available - The GitHub Blog](https://github.blog/changelog/2024-06-25-artifact-attestations-is-generally-available/)
  - https://docs.github.com/en/actions/security-guides/using-artifact-attestations-to-establish-provenance-for-builds
  - https://github.com/actions/attest-build-provenance/tree/v1/